### PR TITLE
When no arguments are specified, execute pick

### DIFF
--- a/bin/lifepicker.py
+++ b/bin/lifepicker.py
@@ -33,4 +33,8 @@ pick_parser.set_defaults(func=pick)
 
 if __name__ == '__main__':
     args = parser.parse_args()
-    args.func()
+    try:
+        args.func()
+    except AttributeError:
+        # When neither 'add' or 'pick' is specified, execute 'pick'
+        pick()


### PR DESCRIPTION
This fixes https://github.com/pirapira/lifepicker/issues/4